### PR TITLE
fix(utils): timezoneOffset date parsing

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -1,12 +1,25 @@
-const INTL_DATE_FORMAT_DEFAULT_OPTION = { year: 'numeric', month: 'long', day: '2-digit', hour: '2-digit', minute: '2-digit', second: '2-digit' }
+const INTL_DATE_FORMAT_DEFAULT_OPTION = {
+  year: "numeric",
+  month: "2-digit",
+  day: "2-digit",
+  hour: "2-digit",
+  minute: "2-digit",
+  second: "2-digit",
+  hourCycle: "h24"
+}
 
 // Create an array of undefined with `count` lenght
 export const initArray = count => Array.from({ length: count }).fill()
 
+export const toISO8601 = date => {
+  const [, day, month, year, hour, minute, second] = date.match(/(\d{2})\/(\d{2})\/(\d{4}).*?(\d{2}):(\d{2}):(\d{2})/)
+  return `${year}-${month}-${day}T${hour}:${minute}:${second}Z`
+};
+
 // Get the difference between given timezone and UTC time in millisecond
 export const timezoneOffset = timeZone => {
   const now = new Date()
-  const utc = new Intl.DateTimeFormat('en-US', { ...INTL_DATE_FORMAT_DEFAULT_OPTION, timeZone: 'UTC' }).format(now)
-  const current = new Intl.DateTimeFormat('en-US', { ...INTL_DATE_FORMAT_DEFAULT_OPTION, timeZone }).format(now)
+  const utc = toISO8601(new Intl.DateTimeFormat('fr-FR', { ...INTL_DATE_FORMAT_DEFAULT_OPTION, timeZone: 'UTC' }).format(now))
+  const current = toISO8601(new Intl.DateTimeFormat('fr-FR', { ...INTL_DATE_FORMAT_DEFAULT_OPTION, timeZone }).format(now))
   return new Date(current).getTime() - new Date(utc).getTime()
 }

--- a/test.js
+++ b/test.js
@@ -1,11 +1,17 @@
 import test from 'ava'
 import timestampUtils from './src'
-import { initArray, timezoneOffset } from './src/utils'
+import { initArray, toISO8601, timezoneOffset } from './src/utils'
 
 // Init an array with length of 3
 test('initArray', t => {
   const array = initArray(3)
   t.is(array.length, 3)
+})
+
+// Turn an Intl.DateTimeFormat date to iso8601 date
+test('toISO8601', t => {
+  const date = toISO8601('14/07/2022, 14:25:39')
+  t.is(date, '2022-07-14T14:25:39Z')
 })
 
 // Get offset between UTC and ... UTC --'


### PR DESCRIPTION
Turn `Intl.DateTimeFormat` date to `iso 8601` for `timezoneOffset` util. 
Close https://github.com/arncet/timestamp-utils/issues/179